### PR TITLE
Add ProgressManager for real-time fetch updates

### DIFF
--- a/api/apiUtilities.js
+++ b/api/apiUtilities.js
@@ -200,6 +200,9 @@ function rateLimitedRequest(url, endpoint) {
   while (!rateLimitStatus.proceed) {
     Logger.log(`Rate limit reached for ${endpoint}. Waiting for ${rateLimitStatus.waitTime} ms.`);
 
+    // Update progress so the UI can indicate waiting time
+    updateProgress(`Waiting ${Math.ceil(rateLimitStatus.waitTime / 1000)} seconds to avoid rate limit`);
+
     // Ensure we don't exceed execution time limits
     if (rateLimitStatus.waitTime > 300000) { // 5 minutes
       throw new Error('Wait time exceeds script execution time limits.');
@@ -207,11 +210,15 @@ function rateLimitedRequest(url, endpoint) {
 
     Utilities.sleep(rateLimitStatus.waitTime);
 
+    // Refresh progress after sleeping in case UI needs to update
+    updateProgress('Resuming request ...');
+
     // Re-check after sleeping so the request gets logged correctly
     rateLimitStatus = canProceedWithRequest(endpoint);
   }
 
   Logger.log('Making API request to URL: ' + url);  // Add this log
+  updateProgress(`Fetching data from ${endpoint}`);
   Logger.log(`Rate-limited request made for: ${url} on endpoint: ${endpoint}`);
 
   // Proceed with the API request

--- a/api/fetchFunctions.js
+++ b/api/fetchFunctions.js
@@ -32,10 +32,14 @@
 function fetchDataAndWriteToSheet(endpoint, sheetName, params = {}, startRow = 2) {
   // Construct the initial API URL
   let url = constructApiUrl(endpoint, params);
-  
+
+  // Inform UI which sheet is being fetched
+  updateProgress(`Fetching data for ${sheetName} ...`);
+
   // Start fetching data
   fetchAndHandleData(url, sheetName, startRow, endpoint);
-  // Format sheet
+
+  // Format sheet when done
   formatSheet(sheetName);
 }
 
@@ -55,9 +59,15 @@ function fetchAndHandleData(url, sheetName, currentRow, endpoint) {
     // Write the data and calculate the next row to write
     const rowsWritten = writeDataToSheet(data.items || data, sheetName, currentRow);
 
+    // Inform UI about progress of written rows
+    updateProgress(`Fetched rows up to ${currentRow + rowsWritten - 1}`);
+
     // If there is more data (pagination), fetch the next page
     if (data.nextPagePath) {
       Logger.log('Fetching next page of data...: ' + data.nextPagePath);
+
+      // Notify the UI that we are fetching another page
+      updateProgress('Fetching additional data ...');
 
       // Construct the next page URL
       const nextPageUrl = constructApiUrl(data.nextPagePath, {}, true);

--- a/css/styles.html
+++ b/css/styles.html
@@ -43,4 +43,10 @@
 .environment-card:hover {
   transform: translateY(-5px);
 }
+
+/* Status message shown while fetching data */
+.progress-status {
+  margin: 10px 0;
+  font-style: italic;
+}
 </style>

--- a/data/sheetManager.js
+++ b/data/sheetManager.js
@@ -149,14 +149,20 @@ if (!sheet) {
   return;
 }
 
-rowData.forEach((row, rowIndex) => {
-  // Flatten the row if any cell contains an array (spread array values across columns)
-  const flattenedRow = row.flatMap(cell => Array.isArray(cell) ? cell : [cell]);
+  rowData.forEach((row, rowIndex) => {
+    // Flatten the row if any cell contains an array (spread array values across columns)
+    const flattenedRow = row.flatMap(cell => Array.isArray(cell) ? cell : [cell]);
+
+    // Notify progress for each row written
+    updateProgress(`Fetching row ${startRow + rowIndex}`);
 
   // Log the row data being written for debugging purposes
   Logger.log(`Writing to ${sheet} and row ${startRow + rowIndex}: ${JSON.stringify(flattenedRow)}`);
 
   // Write the flattened row to the sheet
   sheet.getRange(startRow + rowIndex, 1, 1, flattenedRow.length).setValues([flattenedRow]);
-});
+  });
+
+  // Update progress when a batch of rows is completed
+  updateProgress(`Completed rows through ${startRow + rowData.length - 1}`);
 }

--- a/html/fetchData.html
+++ b/html/fetchData.html
@@ -66,6 +66,7 @@
     <div id="step-fetchingData" class="step">
       <div id="fetch-progress" class="hidden">
         <h5>Fetching Data:</h5>
+        <div id="progress-status" class="progress-status"></div>
           <ul id="progress-list" class="collection">
             <li class="collection-item">
               <div class="progress-item row">

--- a/js/scripts.html
+++ b/js/scripts.html
@@ -356,7 +356,7 @@ function showFetchDataModal() {
  * @description Collects the selected data options from the form, validates the selection,
  *              and calls the server-side function to fetch the data.
  */
- function fetchSelectedData() {
+function fetchSelectedData() {
   const form = document.getElementById('fetch-data-form');
   const selectedOptions = Array.from(form.elements.fetchOption)
     .filter(checkbox => checkbox.checked)
@@ -370,7 +370,11 @@ function showFetchDataModal() {
 
   // Show progress section
   const progressSection = document.getElementById('fetch-progress');
-    progressSection.classList.remove('hidden');
+  progressSection.classList.remove('hidden');
+
+  // Start polling for progress updates
+  pendingFetches = selectedOptions.length;
+  startProgressPolling();
 
     // Create progress items
     const progressList = document.getElementById('progress-list');
@@ -413,10 +417,16 @@ function showFetchDataModal() {
  * @param {*} result - The result returned from the server-side fetch function.
  * @description Displays a success message to the user and closes the fetch data modal.
  */
- function onFetchSuccess(option, result) {
+function onFetchSuccess(option, result) {
   console.log(`onFetchSuccess called for ${option}`);  // Add logging
   updateProgressItem(option, 'complete');
   console.log(`Fetched ${option} successfully:`, result);
+
+  pendingFetches--;
+  if (pendingFetches === 0) {
+    stopProgressPolling();
+    google.script.run.clearProgress();
+  }
 }
 
 /**
@@ -427,10 +437,16 @@ function showFetchDataModal() {
  * @param {Error} error - The error object returned from the server-side fetch function.
  * @description Displays an error message to the user with details about the fetch failure.
  */
- function onFetchError(option, error) {
+function onFetchError(option, error) {
   console.error(`onFetchError called for ${option}`);  // Add logging
   updateProgressItem(option, 'error');
   console.error(`Error fetching ${option}:`, error);
+
+  pendingFetches--;
+  if (pendingFetches === 0) {
+    stopProgressPolling();
+    google.script.run.clearProgress();
+  }
 }
 
 
@@ -466,6 +482,56 @@ jQuery.expr[':'].contains = function(a, i, m) {
   return jQuery(a).text().toUpperCase()
       .indexOf(m[3].toUpperCase()) >= 0;
 };
+
+// ========================= Progress UI Manager ==========================
+
+class ProgressUIManager {
+  constructor(elementId) {
+    this.elementId = elementId;
+    this.element = null;
+    this.interval = null;
+  }
+
+  init() {
+    if (!this.element) {
+      this.element = document.getElementById(this.elementId);
+    }
+  }
+
+  start() {
+    this.init();
+    this.interval = setInterval(() => {
+      google.script.run.withSuccessHandler(message => {
+        if (this.element && message) {
+          this.element.textContent = message;
+        }
+      }).getProgress();
+    }, 1000);
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+}
+
+let progressUiManager;
+let pendingFetches = 0;
+
+function startProgressPolling() {
+  if (!progressUiManager) {
+    progressUiManager = new ProgressUIManager('progress-status');
+  }
+  progressUiManager.start();
+}
+
+function stopProgressPolling() {
+  if (progressUiManager) {
+    progressUiManager.stop();
+  }
+}
 
 /**
  * Closes the current modal.

--- a/main/progressManager.js
+++ b/main/progressManager.js
@@ -1,0 +1,64 @@
+/**
+ * ProgressManager handles storing and retrieving progress messages
+ * so the client UI can display status updates while long running
+ * operations are executing.
+ */
+class ProgressManager {
+  constructor() {
+    this.cache = CacheService.getScriptCache();
+    this.prefix = 'PROGRESS_';
+  }
+
+  /**
+   * Saves a progress message for the given id.
+   * @param {string} id Identifier for the progress entry.
+   * @param {string} message Progress message to store.
+   */
+  setProgress(id, message) {
+    // Cache entries expire after 25 minutes which is below Apps Script limits
+    this.cache.put(this.prefix + id, message, 1500);
+  }
+
+  /**
+   * Retrieves the latest progress message for the given id.
+   * @param {string} id Identifier used when storing progress.
+   * @returns {string} The stored progress message or an empty string.
+   */
+  getProgress(id) {
+    return this.cache.get(this.prefix + id) || '';
+  }
+
+  /**
+   * Clears the progress message for the given id.
+   * @param {string} id Identifier used when storing progress.
+   */
+  clearProgress(id) {
+    this.cache.remove(this.prefix + id);
+  }
+}
+
+// Singleton instance used throughout the project
+const progressManager = new ProgressManager();
+
+/**
+ * Updates the global fetch progress message.
+ * @param {string} message The message to display to the user.
+ */
+function updateProgress(message) {
+  progressManager.setProgress('fetch', message);
+}
+
+/**
+ * Retrieves the current global fetch progress message.
+ * @returns {string} The latest message set via updateProgress().
+ */
+function getProgress() {
+  return progressManager.getProgress('fetch');
+}
+
+/**
+ * Clears the stored fetch progress message.
+ */
+function clearProgress() {
+  progressManager.clearProgress('fetch');
+}


### PR DESCRIPTION
## Summary
- implement `ProgressManager` to store progress messages via CacheService
- show progress status in fetch data modal
- poll progress from client with `ProgressUIManager`
- update fetch routines and rate limiter to report progress
- style progress status display

## Testing
- `node --check main/progressManager.js`
- `node --check api/fetchFunctions.js`
- `node --check api/apiUtilities.js`
- `node --check data/sheetManager.js`


------
https://chatgpt.com/codex/tasks/task_e_684c6c0c1e90832382350a23de8f596a