### PR TITLE
Improve add‑on menu

### DIFF
--- a/ui/menuBuilder.js
+++ b/ui/menuBuilder.js
@@ -3,15 +3,25 @@
  */
 function onOpen() {
   const ui = SpreadsheetApp.getUi();
+
   ui.createMenu('Trading212 Portfolio')
-      .addItem('Setup Account', 'showSetupModal')
-      .addItem('Refresh Data', 'refreshPortfolioData')
-      .addItem('Settings', 'showSettingsModal')
+    .addSubMenu(ui.createMenu('Setup')
+      .addItem('Start Setup', 'showSetupModal')
+      .addItem('Reset Setup', 'resetSetup'))
+    .addSubMenu(ui.createMenu('Data')
+      .addItem('Fetch Data...', 'showFetchDataModal')
       .addSeparator()
-    .addSubMenu(ui.createMenu('Format Configuration')
+      .addItem('Fetch Pies', 'fetchPies')
+      .addItem('Fetch Instruments', 'fetchInstrumentsList')
+      .addItem('Fetch Exchanges', 'fetchExchanges')
+      .addItem('Fetch Account Info', 'fetchAccountInfo')
+      .addItem('Fetch Cash Balance', 'fetchAccountCash')
+      .addItem('Fetch Transactions', 'fetchTransactions')
+      .addItem('Fetch Order History', 'fetchOrderHistory')
+      .addItem('Fetch Dividends', 'fetchDividends'))
+    .addSubMenu(ui.createMenu('Formatting')
       .addItem('Setup Format System', 'setupFormatConfigSystem')
       .addItem('Refresh Column Mapping', 'refreshColumnMapping')
       .addItem('Apply All Formatting', 'applyFormattingToAllSheets'))
-    .addSeparator()
     .addToUi();
 }


### PR DESCRIPTION
## Summary
- restructure the add-on menu
- add data fetching items and a Reset Setup option
- remove unused menu items

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_684db4f0cebc8323b6ac001cd59b408c