### PR TITLE
Add AI coding instructions

### DIFF
--- a/AI_CODING_GUIDE.md
+++ b/AI_CODING_GUIDE.md
@@ -1,0 +1,22 @@
+# AI Coding Guide
+
+This guide explains how coding agents should contribute to this repository.
+
+## Git workflow
+- **Create a branch** from `main` for each change (e.g. `feature/task-42`).
+- Keep commits small and descriptive. Check changes with `git status` before committing.
+- Push the branch and open a pull request once work is complete.
+
+## Checking issues
+- Use `gh issue list` to view open tasks on GitHub.
+- Reference the relevant issue number in your PR body.
+
+## Coding style
+- Follow the folder responsibilities outlined in [ARCHITECTURE.md](ARCHITECTURE.md).
+- Apply DRY principles and keep functions well documented with JSDoc.
+- Maintain separation of responsibilities between `api/`, `data/`, `ui/` and other modules.
+- Aim for incremental, maintainable changes that do not break existing behaviour.
+
+## Deploying with clasp
+- Authenticate once with `clasp login` and ensure `appsscript.json` is present.
+- After merging to `main`, run `clasp push` to sync files with the Apps Script project.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Project Architecture
+
+This document gives an overview of the portfolio tracker add-on. It summarises the main folders, their responsibilities and the way the code interacts. Coding agents can use this as a reference when extending the project.
+
+## Directory overview
+
+- **api/** – Handles all communication with the Trading212 API. Contains utilities, constants, rate limiting and fetch functions.
+- **data/** – Sheet management and formatting helpers. Responsible for writing data retrieved from the API into Google Sheets.
+- **html/**, **js/**, **css/** – Templates and client‑side scripts used by modals and other UI dialogs.
+- **main/** – Core logic such as progress tracking, caching and common utility functions.
+- **ui/** – Builds menus, manages modal dialogs and handles setup interactions.
+- **tasks/** – High‑level development notes and feature ideas.
+
+## High level flow
+
+```mermaid
+flowchart TD
+    subgraph AddOn
+        UI["UI scripts (ui/*)"] -->|triggers| Main
+        Main -->|calls| API
+        Main -->|writes| Data
+        UI -->|renders| HTML
+        HTML -->|uses| CSS
+        HTML -->|uses| JS
+    end
+    API --> Constants
+    API --> RateLimiter
+    Data --> SheetFormatting
+```
+
+- The **menuBuilder** in `ui/` runs on spreadsheet open and exposes actions.
+- UI actions invoke functions in `main/` which orchestrate API calls and progress updates.
+- API utilities fetch portfolio data and respect rate limits.
+- Data helpers format responses and update sheets.
+- Modal dialogs use the HTML/CSS/JS templates under `html/`, `css/` and `js/`.
+


### PR DESCRIPTION
## Summary
- move coding guidelines out of ARCHITECTURE.md
- add a new AI_CODING_GUIDE with git and clasp steps

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684dd557976c832395bf30521e7d928b