### PR TITLE
Implement cursor tracking for incremental API fetches

### DIFF
--- a/main/cursorManager.js
+++ b/main/cursorManager.js
@@ -1,0 +1,37 @@
+/**
+ * Cursor and update management for incremental API fetching.
+ */
+
+function cursorProperty(sheetName) {
+  return `CURSOR_${sheetName}`;
+}
+
+function updatedProperty(sheetName) {
+  return `LAST_UPDATED_${sheetName}`;
+}
+
+function getLastCursor(sheetName) {
+  return PropertiesService.getUserProperties().getProperty(cursorProperty(sheetName));
+}
+
+function setLastCursor(sheetName, cursor) {
+  const props = PropertiesService.getUserProperties();
+  props.setProperty(cursorProperty(sheetName), String(cursor));
+  setSheetLastUpdated(sheetName, String(cursor));
+}
+
+function getLastUpdated(sheetName) {
+  return PropertiesService.getUserProperties().getProperty(updatedProperty(sheetName));
+}
+
+function setSheetLastUpdated(sheetName, timestamp) {
+  const props = PropertiesService.getUserProperties();
+  props.setProperty(updatedProperty(sheetName), timestamp);
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  if (sheet) {
+    const finder = sheet.createTextFinder('Last Updated').findNext();
+    if (finder) {
+      sheet.getRange(finder.getRow(), finder.getColumn() + 1).setValue(timestamp);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- support incremental API fetching by returning last cursor
- update fetch functions to use stored cursor and append new rows
- track cursor and last updated timestamp in `cursorManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684db944bfe48323bb7884b1efd75f1b